### PR TITLE
Removes W3 warning from MSVS when selecting WIN64 or WIN32 Library

### DIFF
--- a/REFPROP_lib.h
+++ b/REFPROP_lib.h
@@ -602,11 +602,17 @@ extern "C" {
     const std::string& get_shared_lib()
     {
 #if defined(__RPISWINDOWS__)
+    #if defined(_WIN64) || defined(__WIN64__)
+        return shared_lib_WIN64;
+    #elif defined(_WIN32) || defined(__WIN32__)
+        return shared_lib_WIN32;
+    #else
         if (sizeof(void*) == 8) { // Assume 64bit
             return shared_lib_WIN64;
         } else {
             return shared_lib_WIN32;
         }
+    #endif  
 #elif defined(__RPISLINUX__)
         return shared_lib_LINUX;
 #elif defined(__RPISAPPLE__)


### PR DESCRIPTION
### Description of the Change

Modified `#if defines` under  REFPROP_IMPLEMENTATION to select the correct shared library for Windows 64-bit or 32-bit, specifically to remove W3 warning in Visual Studio build.

### Benefits

Previous commit results in a W3 warning:

![image](https://user-images.githubusercontent.com/17114032/204684228-a9a9a52f-dbfb-4855-8634-91a6b6a88d7f.png)

This comes from the macro if statement in `get_shared_lib()` under `__RPISWINDOWS__`
```cpp
    const std::string& get_shared_lib()
    {
    #if defined(__RPISWINDOWS__)
        if (sizeof(void*) == 8) { // Assume 64bit
            return shared_lib_WIN64;
        } else {
            return shared_lib_WIN32;
        }
    #elif defined(__RPISLINUX__)
    [...]
    }
```

Basing the 64/32-bit selection first on macros _WIN64 and then _WIN32 makes this library selection seamlessly and disables the `constant conditional expression` that throws the warning.

```cpp
    const std::string& get_shared_lib()
    {
    #if defined(__RPISWINDOWS__)
        #if defined(_WIN64) || defined(__WIN64__)
            return shared_lib_WIN64;
        #elif defined(_WIN32) || defined(__WIN32__)
            return shared_lib_WIN32;
        #else
            if (sizeof(void*) == 8) { // Assume 64bit
                return shared_lib_WIN64;
            } else {
                return shared_lib_WIN32;
            }
        #endif       // defined(_WIN64) || defined(_WIN32)
    #elif defined(__RPISLINUX__)
    [...]
    }
```

### Possible Drawbacks

Assuming that other Windows compilers will either provide the same macro defines (`_WIN64` or `_WIN32`), or fall through to the original code that checks pointer size to determine bit-ness.

### Verification Process

Compiled and ran Mathcad REFPROP wrapper, which is 64-bit and based REFPROP-headers. 

- *How did you verify that all changed functionality works as expected?*  Ran several Mathcad verification sheets - they link to Mathcad with correct bit-ness.
- *How did you verify that the change has not introduced any regressions?* Did not run other Windows compilers (e.g. Ming).  I don't have anything but VS installed.

*Describe the actions you performed (e.g. text you typed, commands you ran, etc.), and describe the results you observed.*  
Compilation/linking would have failed if the wrong bit-ness was auto selected.  It compiled/linked successfully.

### Applicable Issues

None filed.   It's just been an annoyance for a while when compiling under VS with \W3 or \W4 for thorough checking.